### PR TITLE
Use task_info variable name

### DIFF
--- a/discoverecs.py
+++ b/discoverecs.py
@@ -288,7 +288,7 @@ def task_info_to_targets(task_info):
                         ecs_cluster_name=ecs_cluster_name,
                         ec2_instance_id=ec2_instance_id)]
                 else:
-                    log(task['taskArn'] + ' does not have a networkBinding')
+                    log(task_info.task['taskArn'] + ' does not have a networkBinding')
     return []
 
 class Main:


### PR DESCRIPTION
There is no such variable `task` in scope. Should have been `task_info`
as everywhere else in this method.

Thanks for the discovery script - it works great!

@fredsig