### PR TITLE
Add support for random hostPort network bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,8 +136,11 @@ will be exposed and the instance label will always point to the job name.
 
 All network modes are supported (bridge, host and awsvpc).
 
-If PROMETHEUS_PORT is not set, the script will pick the first port from the container
+If PROMETHEUS_PORT and PROMETHEUS_CONTAINER_PORT are not set, the script will pick the first port from the container
 definition (in awsvpc and host network mode) or the container host network bindings
 in bridge mode. On Fargate, if PROMETHEUS_PORT is not set, it will default to port 80.
+
+If PROMETHEUS_CONTAINER_PORT is set, it will look at the container host network bindings, and find the entry with a matching containerPort. It will then use the hostPort found there as target port.
+This is useful when the container port is known, but the hostPort is randomly picked by ECS (by setting hostPort to 0 in the task definition).
 
 If your container uses multiple ports, it's recommended to specify PROMETHEUS_PORT explicitly.

--- a/discoverecs.py
+++ b/discoverecs.py
@@ -285,6 +285,7 @@ def task_info_to_targets(task_info):
         metrics_path = get_environment_var(container_definition['environment'], 'PROMETHEUS_ENDPOINT')
         nolabels = get_environment_var(container_definition['environment'], 'PROMETHEUS_NOLABELS')
         prom_port = get_environment_var(container_definition['environment'], 'PROMETHEUS_PORT')
+        prom_container_port = get_environment_var(container_definition['environment'], 'PROMETHEUS_CONTAINER_PORT')
         if nolabels != 'true': nolabels = None
         containers = filter(lambda c:c['name'] == container_definition['name'], task_info.task['containers'])
         if prometheus:
@@ -298,6 +299,9 @@ def task_info_to_targets(task_info):
                          first_port = str(container_definition['portMappings'][0]['hostPort'])
                      else:
                          first_port = '80'
+                elif prom_container_port:
+                    binding_by_container_port = filter(lambda c:str(c['containerPort']) == prom_container_port, container['networkBindings'])
+                    first_port = str(binding_by_container_port[0]['hostPort'])
                 else:
                     first_port = str(container['networkBindings'][0]['hostPort'])
 


### PR DESCRIPTION
When running ECS containers with a random hostport it's not possible to specify it as PROMETHEUS_PORT, as it is not known until container is created.
This adds support for a new env var `PROMETHEUS_CONTAINER_PORT` which allows script to identify the used hostPort by looking at the port bindings, and selecting the right one based on container port.