### PR TITLE
Allow customisation of default interval

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,4 +5,4 @@ format:
 .PHONY: dev-start
 dev-start:
 	@mkdir -p ./targets
-	poetry run python discoverecs.py --directory $$PWD/targets
+	poetry run python discoverecs.py --directory $$PWD/targets --default-scrape-interval-prefix default

--- a/README.md
+++ b/README.md
@@ -60,8 +60,7 @@ The output directory is then `/opt/prometheus-ecs` defined in your Prometheus co
         regex: (.+)
 ```
 
-You can also specify a discovery interval with `--interval` (in seconds). Default is 60s. We also provide caching to minimize hitting query
-rate limits with the AWS ECS API. `discoverecs.py` runs in a loop until interrupted and will output target information to stdout.
+You can also specify a discovery interval with `--interval` (in seconds). The default is `60s`. We also provide caching to minimize hitting query rate limits with the AWS ECS API. `discoverecs.py` runs in a loop until interrupted and will output target information to stdout.
 
 To make your application discoverable by Prometheus, you need to set the following environment variable in your task definition:
 
@@ -91,7 +90,23 @@ Under ECS task definition (`task.json`):
 
 Available scrape intervals: `15s`, `30s`, `1m`, `5m`.
 
-The default metric path is `/metrics`. The default scrape interval is `1m`.
+The default metric path is `/metrics`.
+
+### Default scrape interval
+
+The default scrape interval is `1m` when no interval is specified in the `PROMETHEUS_ENDPOINT` variable.
+
+This can be customised using the option `--default-scrape-interval`. This can be any string which will result in the targets being output to `/opt/prometheus-ecs/<default_scrape_interval>-tasks.json` being written.
+
+e.g. if `default` is used:
+
+```shell
+--default-scrape-interval default
+```
+
+then `/opt/prometheus-ecs/default-tasks.json` will be written. This can be useful to allow configuration of a default scrape interval in your Prometheus config, rather than needing to update the config and then redeploying this discovery service.
+
+### Configuration yaml
 
 The following Prometheus configuration should be used to support all available intervals:
 

--- a/README.md
+++ b/README.md
@@ -71,8 +71,10 @@ To make your application discoverable by Prometheus, you need to set the followi
 Metric path and scrape interval is supported via `PROMETHEUS_ENDPOINT`:
 
 ```text
-"interval:/metric_path,..."
+"[interval:]<metric_path>,..."
 ```
+
+where `interval` is optional.
 
 Examples:
 

--- a/README.md
+++ b/README.md
@@ -96,12 +96,12 @@ The default metric path is `/metrics`.
 
 The default scrape interval is `1m` when no interval is specified in the `PROMETHEUS_ENDPOINT` variable.
 
-This can be customised using the option `--default-scrape-interval`. This can be any string which will result in the targets being output to `/opt/prometheus-ecs/<default_scrape_interval>-tasks.json` being written.
+This can be customised using the option `--default-scrape-interval-prefix`. This can be any string which will result in the targets being output to `/opt/prometheus-ecs/<default_scrape_interval>-tasks.json` being written.
 
 e.g. if `default` is used:
 
 ```shell
---default-scrape-interval default
+--default-scrape-interval-prefix default
 ```
 
 then `/opt/prometheus-ecs/default-tasks.json` will be written. This can be useful to allow configuration of a default scrape interval in your Prometheus config, rather than needing to update the config and then redeploying this discovery service.

--- a/discoverecs.py
+++ b/discoverecs.py
@@ -457,15 +457,15 @@ def task_info_to_targets(task_info):
 
 
 class Main:
-    def __init__(self, directory, interval, default_scrape_interval):
+    def __init__(self, directory, interval, default_scrape_interval_prefix):
         self.directory = directory
         self.interval = interval
-        self.default_scrape_interval = default_scrape_interval
+        self.default_scrape_interval_prefix = default_scrape_interval_prefix
         self.discoverer = TaskInfoDiscoverer()
 
     def write_jobs(self, jobs):
-        for interval, j in jobs.items():
-            file_name = self.directory + "/" + interval + "-tasks.json"
+        for prefix, j in jobs.items():
+            file_name = self.directory + "/" + prefix + "-tasks.json"
             tmp_file_name = file_name + ".tmp"
             with open(tmp_file_name, "w") as f:
                 f.write(json.dumps(j, indent=4))
@@ -512,7 +512,7 @@ class Main:
                 }
                 if labels:
                     job["labels"].update(labels)
-                jobs[interval or self.default_scrape_interval].append(job)
+                jobs[interval or self.default_scrape_interval_prefix].append(job)
                 log(job)
         self.write_jobs(jobs)
 
@@ -526,19 +526,19 @@ def main():
     arg_parser = argparse.ArgumentParser()
     arg_parser.add_argument("--directory", required=True)
     arg_parser.add_argument("--interval", default=60)
-    arg_parser.add_argument("--default-scrape-interval", default="1m")
+    arg_parser.add_argument("--default-scrape-interval-prefix", default="1m")
     args = arg_parser.parse_args()
     log(
-        "Starting. Directory: "
-        + args.directory
-        + ". Refresh interval: "
-        + str(args.interval)
-        + "s."
+        'Starting...\nDirectory: "{}"\nRefresh interval: "{}s"\nDefault scrape interval prefix: "{}"\n'.format(
+            args.directory,
+            str(args.interval),
+            args.default_scrape_interval_prefix,
+        )
     )
     Main(
         directory=args.directory,
         interval=float(args.interval),
-        default_scrape_interval=args.default_scrape_interval,
+        default_scrape_interval_prefix=args.default_scrape_interval_prefix,
     ).loop()
 
 


### PR DESCRIPTION
This will allow setting this to `default`, and then configuring this via prometheus, rather than having to redeploy this service or updating all our services to use a different default.

e.g when using `--default-scrape-interval-prefix default`

the config will allow setting this to `30s` rather than `1m`

```yaml
- job_name: 'ecs-default'
  scrape_interval: 30s
  file_sd_configs:
      - files:
            - /opt/prometheus-ecs/default-tasks.json
  relabel_configs:
      - source_labels: [metrics_path]
        action: replace
        target_label: __metrics_path__
        regex: (.+)
```