### PR TITLE
feat: Configure target ECS cluster ARN

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,14 @@ If `--tags-to-labels` is set, the given tags will be added to the service discov
 
 If `--tags-to-labels "*"` is provided then _all_ non aws prefixed (`AWS:` or `aws:`) tags will be added.
 
+### Selecting specific cluster ARNs
+
+If you only want to monitor a specific subset of clusters in your ECS account, you can declare them, using the `--cluster-arns` argument. For example:
+
+```
+python discoverecs.py --directory /opt/prometheus-ecs --cluster-arns "arn:aws:ecs:eu-west-1:123456:cluster/staging" "arn:aws:ecs:eu-west-1:123456:cluster/production",
+```
+
 ### Configuration yaml
 
 The following Prometheus configuration should be used to support all available intervals:

--- a/discoverecs.py
+++ b/discoverecs.py
@@ -115,7 +115,7 @@ class TaskInfo:
 
 
 class TaskInfoDiscoverer:
-    def __init__(self, fetch_tags=True):
+    def __init__(self, fetch_tags=True, cluster_arns=[]):
         self.ec2_client = boto3.client("ec2")
         self.ecs_client = boto3.client("ecs")
         self.task_cache = FlipCache()
@@ -123,6 +123,7 @@ class TaskInfoDiscoverer:
         self.container_instance_cache = FlipCache()
         self.ec2_instance_cache = FlipCache()
         self.fetch_tags = fetch_tags
+        self.cluster_arns = cluster_arns
 
     def flip_caches(self):
         self.task_cache.flip()
@@ -297,6 +298,9 @@ class TaskInfoDiscoverer:
         clusters_pages = self.ecs_client.get_paginator("list_clusters").paginate()
         for clusters in clusters_pages:
             for cluster_arn in clusters["clusterArns"]:
+                # Only register selected ARNs.
+                if cluster_arn not in self.cluster_arns:
+                    continue
                 task_infos += self.get_infos_for_cluster(cluster_arn, "EC2")
                 fargate_task_infos += self.get_infos_for_cluster(cluster_arn, "FARGATE")
         self.add_ec2_instances(task_infos)
@@ -482,12 +486,12 @@ def task_info_to_targets(task_info):
 
 class Main:
     def __init__(
-        self, directory, interval, default_scrape_interval_prefix, tags_to_labels
+        self, directory, interval, default_scrape_interval_prefix, tags_to_labels, cluster_arns
     ):
         self.directory = directory
         self.interval = interval
         self.default_scrape_interval_prefix = default_scrape_interval_prefix
-        self.discoverer = TaskInfoDiscoverer(fetch_tags=len(tags_to_labels) > 0)
+        self.discoverer = TaskInfoDiscoverer(fetch_tags=len(tags_to_labels) > 0, cluster_arns=cluster_arns)
         self.tags_to_labels = tags_to_labels
 
     def write_jobs(self, jobs):
@@ -557,7 +561,6 @@ class Main:
             self.discover_tasks()
             time.sleep(self.interval)
 
-
 def main():
     arg_parser = argparse.ArgumentParser()
     arg_parser.add_argument(
@@ -582,6 +585,12 @@ def main():
         default=[],
         help="Task definition tags to convert to labels. Case sensitive.",
     )
+    arg_parser.add_argument(
+        "--cluster-arns",
+        nargs="*",
+        default=[],
+        help="The ARNs of the ECS clusters that should be monitored."
+    )
     args = arg_parser.parse_args()
     log(
         f"""
@@ -590,6 +599,7 @@ Directory: "{args.directory}"
 Refresh interval: "{str(args.interval)}s"
 Default scrape interval prefix: "{args.default_scrape_interval_prefix}"
 Tags to convert to labels: {args.tags_to_labels}
+Clusters to query: {args.cluster_arns}
         """
     )
     Main(
@@ -597,6 +607,7 @@ Tags to convert to labels: {args.tags_to_labels}
         interval=args.interval,
         default_scrape_interval_prefix=args.default_scrape_interval_prefix,
         tags_to_labels=args.tags_to_labels,
+        cluster_arns=args.cluster_arns
     ).loop()
 
 


### PR DESCRIPTION
Allows configuring a specific ECS cluster to monitor, using the `--cluster=ARN` CLI argument.

Fixes #13

If someone could point out how to adjust the log line during startup to include this setting, I'd be happy to include it.